### PR TITLE
enable clean cutover and no submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ GITHUB_ORG=GitHub-Demo
 AUTHORS_FILE=/tmp/authors.txt
 SVN_USERNAME=anonymous
 SVN_PASSWORD=anonymous
+ENABLE_SUBMODULES=true
+MIGRATE_HISTORY=true
 ```
 
 ## Caveats

--- a/_functions.sh
+++ b/_functions.sh
@@ -461,6 +461,8 @@ function _initialize_lfs()
     done
     git add .gitattributes
     git commit -m "Initialized Git-LFS"
+    git reflog expire --expire-unreachable=now --all
+    git gc --prune=now
   fi
 }
 

--- a/_functions.sh
+++ b/_functions.sh
@@ -457,6 +457,7 @@ function _initialize_lfs()
       EXTENSION=$(echo ${FILE}|awk -F'.' {'print " *."$3'})
       git lfs track ${EXTENSION}
       git add ${EXTENSION}
+      git lfs migrate --include="*.${EXTENSION}"
     done
     git add .gitattributes
     git commit -m "Initialized Git-LFS"

--- a/_functions.sh
+++ b/_functions.sh
@@ -203,81 +203,78 @@ function _discover_submodules()
   unset IGNORE_DIRS SUBMODULES ACTIONS SELECTION SUBDIRS choices options MENU FLAGS
   _get_svn_layout
   clear
-  if [[ ${ENABLE_SUBMODULES} ]]
+  echo "Discovering potential submodule candidates..."
+  # Get the potential list of submodules, with branches, tags and trunk
+  svn -R list ${REPO_URL} ${SVN_OPTIONS}|grep -E '(/trunk/$|/branches/$|/tags/$)' > /tmp/submodules.txt
+  # it turns out, some folks have .git in their repos, and this falsely
+  # identifies those as submodules. Let's remove those entries and not
+  # present the user with the option to migrate them
+  sed -i 's/\/.git\//d' /tmp/submodules.txt
+  # Remove empty "trunk", "tags" and "branches" from the list of potentials
+  for DIR in $(cat /tmp/submodules.txt);
+  do
+    FILES=$(svn list ${REPO_URL}/${DIR} ${SVN_OPTIONS})
+    if [[ ${#FILES} -le 1 ]]
+    then
+      sed -i "s/${DIR}/d" /tmp/submodules.txt
+    fi
+  done
+  # Get the path to the submodules
+  export SUBMODULES=$(grep -E '(/trunk/$|/branches/$|/tags/$)' /tmp/submodules.txt|\
+  sed -e 's/trunk\/$//' -e 's/tags\/$//' -e 's/branches\/$//'|sort|uniq)
+
+  # Print a report of the discovered submodules
+  if [[ ${#SUBMODULES} -le 4 ]]
   then
-    echo "Discovering potential submodule candidates..."
-    # Get the potential list of submodules, with branches, tags and trunk
-    svn -R list ${REPO_URL} ${SVN_OPTIONS}|grep -E '(/trunk/$|/branches/$|/tags/$)' > /tmp/submodules.txt
-    # it turns out, some folks have .git in their repos, and this falsely
-    # identifies those as submodules. Let's remove those entries and not
-    # present the user with the option to migrate them
-    sed -i 's/\/.git\//d' /tmp/submodules.txt
-    # Remove empty "trunk", "tags" and "branches" from the list of potentials
-    for DIR in $(cat /tmp/submodules.txt);
-    do
-      FILES=$(svn list ${REPO_URL}/${DIR} ${SVN_OPTIONS})
-      if [[ ${#FILES} -le 1 ]]
+    echo "There were no nested repositories discovered"
+  else
+    options=($(echo ${SUBMODULES}))
+    #Actions to take based on selection
+    function ACTIONS {
+      for NUM in ${!options[@]}; do
+        [[ ${choices[NUM]} ]] && SUBDIRS+="${options[NUM]} "
+      done
+      if [[ ! -z ${SUBDIRS} ]]
       then
-        sed -i "s/${DIR}/d" /tmp/submodules.txt
+        export IGNORE_DIRS=$(echo "'^("${SUBDIRS}")$'"|sed -e 's/ /|/g;s/\/|)/\/)/')
+        export FLAGS+=" --ignore-paths ${IGNORE_DIRS}"
+      fi
+    }
+    #Variables
+    ERROR=" "
+    #Clear screen for menu
+    clear
+    #Menu function
+    function MENU {
+      _print_banner "We have discovered the following folders that contain" \
+        "branches, tags, or trunk. This typically means that teams are using" \
+        "them as separate repositories, but there is no real method of" \
+        "discovering this, outside of the 'svn:externals' property, which is" \
+        "often not used. Please review the following folders and select which" \
+        "ones are to be treated as git submodules"
+        echo ""
+        echo "Discovered Folders"
+        for NUM in ${!options[@]}; do
+          echo "[""${choices[NUM]:- }""]" $(( NUM+1 ))") ${options[NUM]}"
+        done
+        echo "$ERROR"
+    }
+    #Menu loop
+    while MENU && read -e -p "Select the desired options using their number (again to uncheck, ENTER when done): " -n1 SELECTION && [[ -n "${SELECTION}" ]]; do
+      clear
+      if [[ "${SELECTION}" == *[[:digit:]]* && ${SELECTION} -ge 1 && ${SELECTION} -le ${#options[@]} ]]; then
+        (( SELECTION-- ))
+        if [[ "${choices[SELECTION]}" == "+" ]]; then
+          choices[SELECTION]=""
+        else
+          choices[SELECTION]="+"
+        fi
+        ERROR=" "
+      else
+        ERROR="Invalid option: ${SELECTION}"
       fi
     done
-    # Get the path to the submodules
-    export SUBMODULES=$(grep -E '(/trunk/$|/branches/$|/tags/$)' /tmp/submodules.txt|\
-    sed -e 's/trunk\/$//' -e 's/tags\/$//' -e 's/branches\/$//'|sort|uniq)
-
-    # Print a report of the discovered submodules
-    if [[ ${#SUBMODULES} -le 4 ]]
-    then
-      echo "There were no nested repositories discovered"
-    else
-      options=($(echo ${SUBMODULES}))
-      #Actions to take based on selection
-      function ACTIONS {
-        for NUM in ${!options[@]}; do
-          [[ ${choices[NUM]} ]] && SUBDIRS+="${options[NUM]} "
-        done
-        if [[ ! -z ${SUBDIRS} ]]
-        then
-          export IGNORE_DIRS=$(echo "'^("${SUBDIRS}")$'"|sed -e 's/ /|/g;s/\/|)/\/)/')
-          export FLAGS+=" --ignore-paths ${IGNORE_DIRS}"
-        fi
-      }
-      #Variables
-      ERROR=" "
-      #Clear screen for menu
-      clear
-      #Menu function
-      function MENU {
-        _print_banner "We have discovered the following folders that contain" \
-          "branches, tags, or trunk. This typically means that teams are using" \
-          "them as separate repositories, but there is no real method of" \
-          "discovering this, outside of the 'svn:externals' property, which is" \
-          "often not used. Please review the following folders and select which" \
-          "ones are to be treated as git submodules"
-          echo ""
-          echo "Discovered Folders"
-          for NUM in ${!options[@]}; do
-            echo "[""${choices[NUM]:- }""]" $(( NUM+1 ))") ${options[NUM]}"
-          done
-          echo "$ERROR"
-      }
-      #Menu loop
-      while MENU && read -e -p "Select the desired options using their number (again to uncheck, ENTER when done): " -n1 SELECTION && [[ -n "${SELECTION}" ]]; do
-        clear
-        if [[ "${SELECTION}" == *[[:digit:]]* && ${SELECTION} -ge 1 && ${SELECTION} -le ${#options[@]} ]]; then
-          (( SELECTION-- ))
-          if [[ "${choices[SELECTION]}" == "+" ]]; then
-            choices[SELECTION]=""
-          else
-            choices[SELECTION]="+"
-          fi
-          ERROR=" "
-        else
-          ERROR="Invalid option: ${SELECTION}"
-        fi
-      done
-      ACTIONS
-    fi
+    ACTIONS
   fi
 }
 

--- a/settings.ini
+++ b/settings.ini
@@ -16,3 +16,5 @@ SVN_PASSWORD=anonymous
 CONVERT_HISTORY=true
 ## Max file size for the repo. Default=100MB
 MAX_FILE_SIZE=100
+## Find and migrate nested repositories?
+ENABLE_SUBMODULES=false

--- a/svn2github.sh
+++ b/svn2github.sh
@@ -11,8 +11,13 @@ fi
 _welcome
 _setup
 _svn_sizer
-_discover_submodules
-_process_submodules
+if [[ ${ENABLE_SUBMODULES} ]]
+then
+  _discover_submodules
+  _process_submodules
+else
+  _get_svn_layout
+fi
 _git_svn_clone
 (
   cd ${REPO_NAME}

--- a/svn2github.sh
+++ b/svn2github.sh
@@ -11,6 +11,7 @@ fi
 _welcome
 _setup
 _svn_sizer
+## Process submodules
 if [[ ${ENABLE_SUBMODULES} ]]
 then
   _discover_submodules
@@ -24,7 +25,7 @@ _git_svn_clone
   git config http.sslVerify false
   _prepare_github
   _migrate_trunk
-  _add_git_submodules
+  [[ ${ENABLE_SUBMODULES} ]] && _add_git_submodules
   _migrate_tags
   _migrate_branches
 )

--- a/svn2github.sh
+++ b/svn2github.sh
@@ -19,7 +19,14 @@ then
 else
   _get_svn_layout
 fi
-_git_svn_clone
+## Perform a clean cutover or migrate history
+if [[ ${MIGRATE_HISTORY} ]]
+then
+  _git_svn_clone
+else
+  _clean_cutover
+fi
+## Migrate trunk, branches, tags, submodules
 (
   cd ${REPO_NAME}
   git config http.sslVerify false


### PR DESCRIPTION
This PR does the following:

- Enable the _clean cutover_ option in settings
- Enable the ability to skip submodules, with a default of skipping

Closes #2 and #3